### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/telepathy-mission-control.spec
+++ b/rpm/telepathy-mission-control.spec
@@ -23,6 +23,7 @@ BuildRequires:  pkgconfig(gobject-2.0)
 BuildRequires:  pkgconfig(gmodule-no-export-2.0)
 BuildRequires:  pkgconfig(gio-2.0) >= 2.28
 BuildRequires:  pkgconfig(mce)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  libxslt
 BuildRequires:  fdupes
 BuildRequires:  systemd


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>